### PR TITLE
Avoid using of dynamic class properties

### DIFF
--- a/src/IP2LocationLaravel.php
+++ b/src/IP2LocationLaravel.php
@@ -4,6 +4,9 @@ namespace Ip2location\IP2LocationLaravel;
 
 class IP2LocationLaravel
 {
+    private $db;
+    private $ws;
+    
     private function load($mode)
     {
         if ($mode == 'bin')


### PR DESCRIPTION
fix for php 8.2+:

Deprecated:Creation of dynamic property Ip2location\IP2LocationLaravel\IP2LocationLaravel::$db is deprecated